### PR TITLE
Make packing algorithm cancellable

### DIFF
--- a/src/CromulentBisgetti.ContainerPacking/Algorithms/IPackingAlgorithm.cs
+++ b/src/CromulentBisgetti.ContainerPacking/Algorithms/IPackingAlgorithm.cs
@@ -1,5 +1,6 @@
 ﻿using CromulentBisgetti.ContainerPacking.Entities;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace CromulentBisgetti.ContainerPacking.Algorithms
 {
@@ -13,7 +14,8 @@ namespace CromulentBisgetti.ContainerPacking.Algorithms
 		/// </summary>
 		/// <param name="container">The container.</param>
 		/// <param name="items">The items to pack.</param>
+		/// <param name="cancellationToken">Algorith will check this token to detect if the current packing attempt should be cancelled.</param>
 		/// <returns>The algorithm packing result.</returns>
-		AlgorithmPackingResult Run(Container container, List<Item> items);
+		AlgorithmPackingResult Run(Container container, List<Item> items, CancellationToken cancellationToken);
 	}
 }

--- a/src/CromulentBisgetti.ContainerPacking/PackingService.cs
+++ b/src/CromulentBisgetti.ContainerPacking/PackingService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CromulentBisgetti.ContainerPacking
@@ -21,6 +22,13 @@ namespace CromulentBisgetti.ContainerPacking
 		/// <param name="algorithmTypeIDs">The list of algorithm type IDs to use for packing.</param>
 		/// <returns>A container packing result with lists of the packed and unpacked items.</returns>
 		public static List<ContainerPackingResult> Pack(List<Container> containers, List<Item> itemsToPack, List<int> algorithmTypeIDs)
+        {
+			var source = new CancellationTokenSource();
+		
+			return Pack(containers, itemsToPack, algorithmTypeIDs, source.Token);
+        }
+
+		public static List<ContainerPackingResult> Pack(List<Container> containers, List<Item> itemsToPack, List<int> algorithmTypeIDs, CancellationToken cancellationToken)
 		{
 			Object sync = new Object { };
 			List<ContainerPackingResult> result = new List<ContainerPackingResult>();
@@ -45,7 +53,7 @@ namespace CromulentBisgetti.ContainerPacking
 
 					Stopwatch stopwatch = new Stopwatch();
 					stopwatch.Start();
-					AlgorithmPackingResult algorithmResult = algorithm.Run(container, items);
+					AlgorithmPackingResult algorithmResult = algorithm.Run(container, items, cancellationToken);
 					stopwatch.Stop();
 
 					algorithmResult.PackTimeInMilliseconds = stopwatch.ElapsedMilliseconds;

--- a/src/CromulentBisgetti.ContainerPackingTests/ContainerPackingCancelTests.cs
+++ b/src/CromulentBisgetti.ContainerPackingTests/ContainerPackingCancelTests.cs
@@ -1,0 +1,54 @@
+﻿using CromulentBisgetti.ContainerPacking;
+using CromulentBisgetti.ContainerPacking.Algorithms;
+using CromulentBisgetti.ContainerPacking.Entities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CromulentBisgetti.ContainerPackingTests
+{
+    [TestClass]
+    public class ContainerPackingCancelTests
+    {
+        [TestMethod]
+        public async Task LongRunningTest_CanBeCancelled()
+        {
+            // One of the longer-running 700 tests, #479
+            var itemsToPack = new List<Item>
+            {
+                new Item(1, 64, 48, 64, 14),
+                new Item(2, 79, 25, 79, 23),
+                new Item(3, 89, 85, 89, 19),
+                new Item(4, 79, 66, 79, 17),
+                new Item(5, 79, 54, 79, 16),
+                new Item(6, 115, 95, 115, 11),
+                new Item(7, 76, 54, 76, 20),
+                new Item(8, 80, 44, 80, 10),
+                new Item(9, 66, 33, 66, 15),
+                new Item(10, 50, 32, 50, 15),
+                new Item(11, 116, 93, 116, 19),
+                new Item(12, 113, 64, 113, 11),
+            };
+            var containers = new List<Container>
+            {
+                new Container(1, 587, 233, 220),
+            };
+
+            var source = new CancellationTokenSource();
+
+            // start the packing task on another thread and give it a bit of time to start
+            var packingTask = Task.Run(() =>
+                        PackingService.Pack(containers, itemsToPack, new List<int> { (int)AlgorithmType.EB_AFIT }, source.Token));
+            await Task.Delay(50);
+
+            // then cancel it. Packing should return quickly
+            source.Cancel();
+
+            var result = await packingTask;
+
+            var elapsedMilliSec = result[0].AlgorithmPackingResults[0].PackTimeInMilliseconds;
+            Assert.IsTrue(elapsedMilliSec < 100, $"Expected elapsed time to be less than 100 but found {elapsedMilliSec} msec");
+        }
+    }
+}


### PR DESCRIPTION
Pass a cancellation token to the packing algorithm, making it possible to cancel the packer should it take too long.
Small change to make the '700 examples' test independent of local machine by always explicitly converting decimals with a decimal point.