### PR TITLE
Fix wrong condition

### DIFF
--- a/src/CromulentBisgetti.ContainerPacking/Algorithms/EB_AFIT.cs
+++ b/src/CromulentBisgetti.ContainerPacking/Algorithms/EB_AFIT.cs
@@ -403,7 +403,7 @@ namespace CromulentBisgetti.ContainerPacking.Algorithms
 
 			for (y = 1; y <= itemsToPackCount; y = y + itemsToPack[y].Quantity)
 			{
-				for (x = y; x < x + itemsToPack[y].Quantity - 1; x++)
+				for (x = y; x < y + itemsToPack[y].Quantity - 1; x++)
 				{
 					if (!itemsToPack[x].IsPacked) break;
 				}
@@ -548,8 +548,6 @@ namespace CromulentBisgetti.ContainerPacking.Algorithms
 
 				itemsToPackCount += item.Quantity;
 			}
-
-			itemsToPack.Add(new Item(0, 0, 0, 0, 0));
 
 			totalContainerVolume = container.Length * container.Height * container.Width;
 			totalItemVolume = 0.0M;


### PR DESCRIPTION
The condition of the `FindBox` inner loop is wrong and allows `x` go beyond `itemsToPack[y].Quantity` iterations as soon as `Quantity > 1`. As a result, the analyzed box may be one of another box "type", and will be analyzed again later by following iterations of outer loop.

The empty item added in `Initialize` serves no purpose anymore since it just prevented OutOfRange exceptions caused by the wrong check discussed above.