### PR TITLE
Smal inefficiency.

### DIFF
--- a/src/CromulentBisgetti.ContainerPacking/Algorithms/EB_AFIT.cs
+++ b/src/CromulentBisgetti.ContainerPacking/Algorithms/EB_AFIT.cs
@@ -619,7 +619,7 @@ namespace CromulentBisgetti.ContainerPacking.Algorithms
 						if (exdim == layers[k].LayerDim)
 						{
 							same = true;
-							continue;
+							break;
 						}
 					}
 


### PR DESCRIPTION
If we found an integer with the same value we should exit the for loop by calling break; instead of continue;